### PR TITLE
Use locale strings for UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,7 +18,7 @@
 
     <!-- Collapsible Side Panel for Scores -->
     <div id="scores-panel-container" class="panel-container side-panel closed">
-        <button id="scores-panel-toggle" class="panel-toggle side-toggle" title="Toggle Scores Panel">
+        <button id="scores-panel-toggle" class="panel-toggle side-toggle">
             <i data-lucide="list-ordered"></i>
         </button>
         <div id="scores-panel-content" class="panel-content">
@@ -28,7 +28,7 @@
 
     <!-- Collapsible Bottom Panel for Totals -->
     <div id="totals-panel-container" class="panel-container bottom-panel closed">
-        <button id="totals-panel-toggle" class="panel-toggle bottom-toggle" title="Toggle Totals Panel">
+        <button id="totals-panel-toggle" class="panel-toggle bottom-toggle">
             <i data-lucide="bar-chart-3"></i>
         </button>
         <div id="totals-panel-content" class="panel-content">


### PR DESCRIPTION
## Summary
- load locale/es.json and expose helper for translations
- replace hard-coded Spanish text in header, setup, panels, and dialogs with locale strings
- set HTML language and toggle titles dynamically

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0cebc68b08322a4bc7eb1ef820440