### PR TITLE
feat: move round actions to header and disable future rounds

### DIFF
--- a/locale/es.json
+++ b/locale/es.json
@@ -17,15 +17,16 @@
   },
   "play": {
     "table": {
-      "actions": "Acciones",
       "bid": "Apuesta",
       "actual": "Hecho",
-      "enterBid": "Apuesta",
-      "enterActual": "Hechos",
       "unlockBids": "Desbloquear apuestas",
-      "undo": "Deshacer",
       "bidsInvalid": "La suma de apuestas es igual al número de la ronda (no permitido)",
       "actualsInvalid": "Los hechos deben sumar el número de la ronda"
+    },
+    "headerActions": {
+      "bids": "Ronda {round}: Apuestas",
+      "actuals": "Ronda {round}: Hechos",
+      "undo": "Ronda {round}: Deshacer"
     },
     "panels": {
       "scores": "Puntos por ronda",

--- a/style.css
+++ b/style.css
@@ -250,6 +250,9 @@ tbody tr:nth-child(odd) { background-color: rgba(15, 23, 42, 0.4); }
 .current-round-row {
     box-shadow: 0 0 0 1px var(--sky-500)/0.4;
 }
+.upcoming-round-row {
+    opacity: 0.4;
+}
 .invalid-round-row { background-color: rgba(159, 18, 57, 0.3) !important; }
 
 .commander-name {


### PR DESCRIPTION
## Summary
- move current round actions from table rows to header controls
- fade upcoming rounds and remove unused Actions column
- add translations for new round action buttons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a23663d360832296bcbe7e676cc9dc