### PR TITLE
Add undo control for previous round

### DIFF
--- a/script.js
+++ b/script.js
@@ -238,6 +238,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         let controls = '';
         if (state.step === "play") {
             const currentRoundIndex = state.roundsData.findIndex(r => r.phase !== "done");
+            const prevRoundIndex = currentRoundIndex - 1;
             if (currentRoundIndex !== -1) {
                 const rd = state.roundsData[currentRoundIndex];
                 if (rd.phase === 'bids') {
@@ -257,13 +258,15 @@ document.addEventListener("DOMContentLoaded", async () => {
                             <i data-lucide="calculator" style="width:16px; height:16px;"></i> ${t('play.headerActions.actuals', { round: rd.r })}
                         </button>
                     `;
-                } else if (rd.phase === 'done') {
-                    controls = `
-                        <button class="btn btn-secondary" data-action="revert-final" data-round-index="${currentRoundIndex}">
-                            ${t('play.headerActions.undo', { round: rd.r })}
-                        </button>
-                    `;
                 }
+            }
+            if (prevRoundIndex >= 0 && state.roundsData[prevRoundIndex]?.phase === 'done') {
+                const prevRound = state.roundsData[prevRoundIndex];
+                controls += `
+                    <button class="btn btn-secondary" data-action="revert-final" data-round-index="${prevRoundIndex}">
+                        ${t('play.headerActions.undo', { round: prevRound.r })}
+                    </button>
+                `;
             }
         }
         return `


### PR DESCRIPTION
## Summary
- Compute previous round index in header and show undo button when last round is complete
- Hook undo button into existing revert-final handler

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a323ad5e9483229fc76d6ead04c3fe