### PR TITLE
Add commander ordering and enforce three-player minimum

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ Simple web‑based scoreboard for the **Quiz!** card game.
 The interface text is in Spanish and runs entirely in the browser.
 
 ## Features
-- Player setup screen (2–6 players) with dynamic round count.
+- Player setup screen (3–6 players) with dynamic round count.
 - Rotating commander shown next to each round number.
 - Bids and actuals entered in modal dialogs with validation and in-dialog lock/finalize actions.
 - Automatic scoring, per-round and cumulative summaries.

--- a/locale/es.json
+++ b/locale/es.json
@@ -11,7 +11,7 @@
     "playerNameLabel": "Nombre del jugador {index}",
     "playerPlaceholder": "Jugador {index}",
     "clearName": "Borrar",
-    "playerCountLabel": "Número de jugadores (2–6)",
+    "playerCountLabel": "Número de jugadores (3–6)",
     "roundsFormula": "Rondas = ⌊52 / P⌋ = {rounds}",
     "startGame": "Iniciar partida"
   },
@@ -36,6 +36,11 @@
       "statExactHits": "Ganados",
       "toggleScores": "Mostrar/ocultar panel de puntuaciones",
       "toggleTotals": "Mostrar/ocultar panel de totales"
+    },
+    "roles": {
+      "commander": "Reparte",
+      "bidder": "Dice",
+      "starter": "Parte"
     }
   },
   "dialogs": {

--- a/script.js
+++ b/script.js
@@ -126,7 +126,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     // State Changers & Actions
     // -----------------------------
     function startGame(playerNames) {
-        const P = clamp(playerNames.length, 2, 6);
+        const P = clamp(playerNames.length, 3, 6);
         const newPlayers = playerNames.slice(0, P).map((n, i) => ({ id: `p${i + 1}`, name: n.trim() || t('setup.playerPlaceholder', { index: i + 1 }) }));
         const R = roundsForPlayers(P);
         
@@ -144,7 +144,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     
     function updatePlayerCount(newCount) {
-        const P = clamp(newCount, 2, 6);
+        const P = clamp(newCount, 3, 6);
         state.playerCount = P;
         const currentPlayers = state.players.map(p => p.name);
         const nextPlayers = Array.from({ length: P }, (_, i) => ({
@@ -319,7 +319,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                                 id="player-count"
                                 class="input"
                                 type="number"
-                                min="2"
+                                min="3"
                                 max="6"
                                 step="1"
                                 value="${state.playerCount}"
@@ -532,6 +532,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (!open) { bidsDialogEl.close(); return; }
 
         const rd = state.roundsData[roundIndex];
+        const commanderIndex = roundIndex % state.players.length;
+        const orderedPlayers = [
+            ...state.players.slice(commanderIndex),
+            ...state.players.slice(0, commanderIndex)
+        ];
         const tempBids = { ...rd.bids };
 
         const updateDialogState = () => {
@@ -555,16 +560,18 @@ document.addEventListener("DOMContentLoaded", async () => {
                 <p>${t('dialogs.bids.instruction', { round: rd.r })}</p>
             </div>
             <div class="dialog-body">
-                ${state.players.map(p => `
+                ${orderedPlayers.map((p, i) => {
+                    const tag = i === 0 ? t('play.roles.commander') : i === 1 ? t('play.roles.bidder') : i === 2 ? t('play.roles.starter') : '';
+                    return `
                     <div class="dialog-player-row">
-                        <span class="player-name">${p.name}</span>
+                        <span class="player-name">${p.name}${tag ? ` <span class=\"badge badge-role\">${tag}</span>` : ''}</span>
                         <div class="input-group">
                             <button class="btn btn-secondary btn-icon" data-action="dec" data-player-id="${p.id}">-</button>
                             <input type="number" class="input bid-input" min="0" max="${rd.r}" value="${tempBids[p.id] ?? ''}" data-player-id="${p.id}">
                             <button class="btn btn-secondary btn-icon" data-action="inc" data-player-id="${p.id}">+</button>
                         </div>
-                    </div>
-                `).join('')}
+                    </div>`;
+                }).join('')}
             </div>
             <div class="dialog-footer">
                 <div class="footer-actions">

--- a/style.css
+++ b/style.css
@@ -222,6 +222,13 @@ header .controls {
     border-color: rgba(192, 38, 211, 0.3);
 }
 
+/* Role badge */
+.badge-role {
+  background-color: rgba(148, 163, 184, 0.2); /* slate-400/20 */
+  color: var(--slate-200);
+  border-color: rgba(100, 116, 139, 0.3); /* slate-500/30 */
+}
+
 /* Table */
 .table-wrapper { overflow-x: auto; }
 table {
@@ -418,7 +425,7 @@ dialog::backdrop { background-color: rgba(0, 0, 0, 0.7); backdrop-filter: blur(4
   border: 1px solid var(--slate-800);
   background-color: rgba(15, 23, 42, 0.7);
 }
-.dialog-player-row .player-name { font-weight: 500; }
+.dialog-player-row .player-name { display:flex; align-items:center; gap:0.5rem; font-weight: 500; }
 .dialog-player-row .input-group { display: flex; align-items: center; gap: 0.5rem; }
 .dialog-player-row .input { width: 5rem; text-align: center; font-size: 1.125rem; }
 .dialog-footer {


### PR DESCRIPTION
## Summary
- Enforce minimum of three players and update setup controls
- Show commander, bidder, and starter roles with badges in bids dialog

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a34ff141f48322824c0aaed41f2021